### PR TITLE
update-login with sessions-cookie

### DIFF
--- a/app/components/Login.js
+++ b/app/components/Login.js
@@ -20,7 +20,7 @@ class Login extends Component {
 		this.props.logIn(this.state);
 	};
 	render() {
-		console.log(this.props)
+		// console.log(this.props)
 		const { authError } = this.props.errorMessage;
 		const { logInStatus } = this.props.userLoginStatus;
 		return (

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -109,12 +109,17 @@ router.post('/login', (req, res, next) => {
       if (userOrNull) {
         User.update(
           {
-            loggedIn: true
+            sessionId: req.cookies.session_id,
+            loggedIn:true
           },
           {
             where: { email, password },
-            returning: true
-          }
+            returning: req.cookies.session_id
+          },
+          res.cookie('session_id',req.cookies.session_id,{
+            path: '/',
+            expires: new Date(Date.now() + 1000 * 60 * 60)
+          })
         );
         return res.status(202).send(userOrNull);
       }


### PR DESCRIPTION
Updated now that when a user logs in to the application, we can associate that session_id when visiting the app is the same cookie(**same session UUID**) , as well the tables being updated with the loggedin user being associated with that session_id. 

Not sure if we would want to delete the guest row in the users table cause we don't want to lose information about who they were before they sign in.